### PR TITLE
feat: Add SQL query improvement feature with current_sql context

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,20 @@
+require:
+  - rubocop-minitest
+  - rubocop-rake
+
 AllCops:
   TargetRubyVersion: 3.2
+  NewCops: enable
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+
+Metrics/ClassLength:
+  Exclude:
+    - "test/**/*"
+
+Minitest/MultipleAssertions:
+  Max: 10

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,6 @@ gem "minitest", "~> 5.16"
 gem "sqlite3", "~> 2.0" # For tests
 
 gem "rubocop", "~> 1.21"
+
+gem "rubocop-minitest", "~> 0.39.1", group: :development
+gem "rubocop-rake", "~> 0.7.1", group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,13 @@ GEM
     rubocop-ast (1.47.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
+    rubocop-minitest (0.39.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+    rubocop-rake (0.7.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
     ruby-openai (6.5.0)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
@@ -262,6 +269,8 @@ DEPENDENCIES
   minitest (~> 5.16)
   rake (~> 13.0)
   rubocop (~> 1.21)
+  rubocop-minitest (~> 0.39.1)
+  rubocop-rake (~> 0.7.1)
   sqlite3 (~> 2.0)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -232,6 +234,7 @@ GEM
     safely_block (0.5.0)
     securerandom (0.4.1)
     sqlite3 (2.8.1-arm64-darwin)
+    sqlite3 (2.8.1-x86_64-linux-gnu)
     stringio (3.1.9)
     thor (1.4.0)
     timeout (0.6.0)
@@ -251,6 +254,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-25
+  x86_64-linux
 
 DEPENDENCIES
   blazer-querygen!

--- a/app/assets/javascripts/blazer/querygen/prompts.js
+++ b/app/assets/javascripts/blazer/querygen/prompts.js
@@ -68,10 +68,18 @@
       return;
     }
 
+    // Get current SQL from editor
+    const currentSql = getEditorValue().trim();
+
     // Disable button and show loading state
     generateBtn.disabled = true;
     generateBtn.textContent = 'Generating...';
-    showStatus('Generating SQL query...', 'info');
+
+    // Show appropriate status message
+    const statusMessage = currentSql
+      ? 'Improving SQL query...'
+      : 'Generating SQL query...';
+    showStatus(statusMessage, 'info');
 
     // Get data source if available
     const dataSourceSelect = document.querySelector('select[name="data_source"]') ||
@@ -91,6 +99,7 @@
       },
       body: JSON.stringify({
         prompt: prompt,
+        current_sql: currentSql || null,
         data_source: dataSource
       })
     })
@@ -99,7 +108,12 @@
         if (data.success) {
           // Set the SQL in Ace Editor
           setEditorValue(data.sql);
-          showStatus('Query generated successfully!', 'success');
+
+          // Show appropriate success message
+          const successMessage = currentSql
+            ? 'Query improved successfully!'
+            : 'Query generated successfully!';
+          showStatus(successMessage, 'success');
         } else {
           showStatus('Error: ' + (data.error || 'Unknown error'), 'error');
         }
@@ -112,6 +126,28 @@
         generateBtn.disabled = false;
         generateBtn.textContent = 'Generate Query with AI';
       });
+  }
+
+  function getEditorValue() {
+    // Try to get value from Ace Editor
+    const aceEditor = document.querySelector('.ace_editor');
+
+    if (aceEditor && window.ace) {
+      // Get Ace editor instance
+      const editor = ace.edit(aceEditor);
+      if (editor) {
+        return editor.getValue();
+      }
+    }
+
+    // Fallback: try to get from regular textarea
+    const textarea = document.querySelector('textarea[name="statement"]') ||
+                    document.querySelector('textarea[name="query[statement]"]');
+    if (textarea) {
+      return textarea.value;
+    }
+
+    return '';
   }
 
   function setEditorValue(sql) {

--- a/app/controllers/blazer/prompts_controller.rb
+++ b/app/controllers/blazer/prompts_controller.rb
@@ -3,7 +3,7 @@
 module Blazer
   # Controller for AI-powered query generation
   class PromptsController < BaseController
-    def run
+    def run # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       prompt = params[:prompt]
       data_source = params[:data_source]
       current_sql = params[:current_sql]
@@ -30,7 +30,7 @@ module Blazer
       render json: { error: "Query generation failed: #{e.message}", success: false }, status: :internal_server_error
     end
 
-    def health
+    def health # rubocop:disable Metrics/MethodLength
       if Blazer::Querygen.config.api_key.present?
         render json: {
           status: "configured",

--- a/app/controllers/blazer/prompts_controller.rb
+++ b/app/controllers/blazer/prompts_controller.rb
@@ -6,6 +6,7 @@ module Blazer
     def run
       prompt = params[:prompt]
       data_source = params[:data_source]
+      current_sql = params[:current_sql]
 
       if prompt.blank?
         render json: { error: "Prompt is required", success: false }, status: :unprocessable_entity
@@ -13,7 +14,7 @@ module Blazer
       end
 
       query_generator = Blazer::Querygen::QueryGenerator.new
-      result = query_generator.generate(prompt: prompt, data_source: data_source)
+      result = query_generator.generate(prompt: prompt, data_source: data_source, current_sql: current_sql)
       render json: result
     rescue Blazer::Querygen::QueryGenerator::UnsafeQueryError => e
       render json: { error: e.message, success: false }, status: :unprocessable_entity

--- a/blazer-querygen.gemspec
+++ b/blazer-querygen.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/SonicGarden/blazer-querygen"
   spec.metadata["changelog_uri"] = "https://github.com/SonicGarden/blazer-querygen/blob/main/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/lib/blazer/querygen.rb
+++ b/lib/blazer/querygen.rb
@@ -10,6 +10,7 @@ require_relative "querygen/view_helpers" if defined?(Rails)
 require_relative "querygen/engine" if defined?(Rails)
 
 module Blazer
+  # AI-powered SQL query generation engine for Blazer
   module Querygen
     class Error < StandardError; end
 

--- a/lib/blazer/querygen/ai_client.rb
+++ b/lib/blazer/querygen/ai_client.rb
@@ -19,11 +19,11 @@ module Blazer
         @client = OpenAI::Client.new(access_token: @api_key)
       end
 
-      def generate_query(prompt:, schema:)
+      def generate_query(prompt:, schema:, current_sql: nil)
         with_retry do
           # Build prompts using PromptBuilder
           system_prompt_content = PromptBuilder.system_prompt
-          user_prompt_content = PromptBuilder.build_user_prompt(prompt, schema)
+          user_prompt_content = PromptBuilder.build_user_prompt(prompt, schema, current_sql: current_sql)
 
           parameters = {
             model: @model,

--- a/lib/blazer/querygen/ai_client.rb
+++ b/lib/blazer/querygen/ai_client.rb
@@ -19,8 +19,8 @@ module Blazer
         @client = OpenAI::Client.new(access_token: @api_key)
       end
 
-      def generate_query(prompt:, schema:, current_sql: nil)
-        with_retry do
+      def generate_query(prompt:, schema:, current_sql: nil) # rubocop:disable Metrics/MethodLength
+        with_retry do # rubocop:disable Metrics/BlockLength
           # Build prompts using PromptBuilder
           system_prompt_content = PromptBuilder.system_prompt
           user_prompt_content = PromptBuilder.build_user_prompt(prompt, schema, current_sql: current_sql)
@@ -77,12 +77,12 @@ module Blazer
         content.gsub(/```sql\n?/, "").gsub(/```\n?/, "").strip
       end
 
-      def with_retry(max_retries: Blazer::Querygen.config.max_retries, &block)
+      def with_retry(max_retries: Blazer::Querygen.config.max_retries, &) # rubocop:disable Metrics/MethodLength
         attempts = 0
         begin
           attempts += 1
-          Timeout.timeout(Blazer::Querygen.config.timeout, &block)
-        rescue Timeout::Error, Net::OpenTimeout => e
+          Timeout.timeout(Blazer::Querygen.config.timeout, &)
+        rescue Net::OpenTimeout => e
           retry if attempts < max_retries
           raise TimeoutError, "API request timed out after #{max_retries} attempts: #{e.message}"
         rescue StandardError => e

--- a/lib/blazer/querygen/configuration.rb
+++ b/lib/blazer/querygen/configuration.rb
@@ -7,7 +7,7 @@ module Blazer
       # OpenAI settings
       attr_accessor :ai_model
       attr_accessor :api_key, :allowed_operations, :max_retries, :max_tables_in_context, :include_column_comments,
-                    :excluded_tables
+                    :excluded_tables, :user_prompt_template
 
       # Security settings
       attr_accessor :sanitize_queries
@@ -20,7 +20,6 @@ module Blazer
 
       # Prompt customization settings
       attr_accessor :system_prompt
-      attr_accessor :user_prompt_template
 
       def initialize
         @ai_model = "gpt-5.2"

--- a/lib/blazer/querygen/configuration.rb
+++ b/lib/blazer/querygen/configuration.rb
@@ -21,7 +21,7 @@ module Blazer
       # Prompt customization settings
       attr_accessor :system_prompt
 
-      def initialize
+      def initialize # rubocop:disable Metrics/MethodLength
         @ai_model = "gpt-5.2"
         @api_key = ENV.fetch("OPENAI_API_KEY", nil)
 

--- a/lib/blazer/querygen/prompt_builder.rb
+++ b/lib/blazer/querygen/prompt_builder.rb
@@ -25,6 +25,8 @@ module Blazer
           5. Include appropriate JOINs based on table relationships
           6. Add LIMIT clauses for safety when appropriate
           7. Use table and column names exactly as provided in the schema
+          8. When a current SQL query is provided, use it as a starting point and improve/modify it based on the user's request
+          9. Preserve the intent of the current query while applying the requested changes
 
           BLAZER CHART VISUALIZATION:
           Blazer automatically generates charts based on column types and order. Consider these patterns:
@@ -58,25 +60,45 @@ module Blazer
       #
       # @param natural_language_query [String] User's natural language request
       # @param schema [Array<Hash>] Database schema extracted by SchemaExtractor
+      # @param current_sql [String, nil] Optional current SQL query to improve/modify
       # @return [String] Complete user prompt with schema context
-      def self.build_user_prompt(natural_language_query, schema)
+      def self.build_user_prompt(natural_language_query, schema, current_sql: nil)
         formatted_schema = format_schema(schema)
 
         # Use custom template if configured
         if Blazer::Querygen.config.user_prompt_template.present?
-          return Blazer::Querygen.config.user_prompt_template.call(natural_language_query, formatted_schema)
+          return Blazer::Querygen.config.user_prompt_template.call(natural_language_query, formatted_schema,
+                                                                   current_sql)
         end
 
-        # Default template (matches AIClient's original implementation)
-        <<~PROMPT
+        # Default template - build prompt based on whether current_sql is provided
+        base_prompt = <<~PROMPT
           Generate a SQL query for the following request:
           #{natural_language_query}
+        PROMPT
+
+        # Add current SQL context if provided
+        if current_sql.present?
+          base_prompt += <<~PROMPT
+
+
+            Current SQL query (use this as a starting point and improve/modify it based on the request above):
+            ```sql
+            #{current_sql}
+            ```
+          PROMPT
+        end
+
+        base_prompt += <<~PROMPT
+
 
           Database Schema:
           #{formatted_schema}
 
           Return only the SQL query without any explanation or formatting.
         PROMPT
+
+        base_prompt
       end
 
       # Format schema array into human-readable text

--- a/lib/blazer/querygen/prompt_builder.rb
+++ b/lib/blazer/querygen/prompt_builder.rb
@@ -9,7 +9,7 @@ module Blazer
       # Uses custom prompt if configured, otherwise returns default
       #
       # @return [String] System prompt instructing AI on SQL generation rules
-      def self.system_prompt
+      def self.system_prompt # rubocop:disable Metrics/MethodLength
         # Use custom prompt if configured
         return Blazer::Querygen.config.system_prompt if Blazer::Querygen.config.system_prompt.present?
 
@@ -50,7 +50,7 @@ module Blazer
           - Use column name: geojson for geographic boundaries
 
           Special Column Names:
-          - "target": Adds a goal/threshold line to charts - Example: SELECT date, COUNT(*) AS users, 1000 AS target FROM signups GROUP BY 1
+          - "target": Adds a goal/threshold line to charts - Example: SELECT date, COUNT(*) AS users, 1000 AS target FROM sign_ups GROUP BY 1
           - Column order matters! Ensure the first column matches the chart type you want.
         PROMPT
       end
@@ -62,7 +62,7 @@ module Blazer
       # @param schema [Array<Hash>] Database schema extracted by SchemaExtractor
       # @param current_sql [String, nil] Optional current SQL query to improve/modify
       # @return [String] Complete user prompt with schema context
-      def self.build_user_prompt(natural_language_query, schema, current_sql: nil)
+      def self.build_user_prompt(natural_language_query, schema, current_sql: nil) # rubocop:disable Metrics/MethodLength
         formatted_schema = format_schema(schema)
 
         # Use custom template if configured

--- a/lib/blazer/querygen/query_generator.rb
+++ b/lib/blazer/querygen/query_generator.rb
@@ -21,7 +21,7 @@ module Blazer
       # @raise [AIClient::APIError] If OpenAI API request fails
       # @raise [AIClient::TimeoutError] If OpenAI API request times out
       # @raise [AIClient::ConfigurationError] If OpenAI API key is missing
-      def generate(prompt:, data_source: nil, current_sql: nil)
+      def generate(prompt:, data_source: nil, current_sql: nil) # rubocop:disable Metrics/MethodLength
         # Extract schema
         schema_extractor = SchemaExtractor.new
         schema = schema_extractor.extract(data_source)

--- a/lib/blazer/querygen/query_generator.rb
+++ b/lib/blazer/querygen/query_generator.rb
@@ -11,6 +11,7 @@ module Blazer
       #
       # @param prompt [String] Natural language description of desired query
       # @param data_source [String, nil] Optional data source name (for future multi-datasource support)
+      # @param current_sql [String, nil] Optional current SQL query to improve/modify
       # @return [Hash] Result hash with keys:
       #   - :sql [String] Generated SQL query (sanitized if config.sanitize_queries is true)
       #   - :prompt [String] Original prompt
@@ -20,14 +21,14 @@ module Blazer
       # @raise [AIClient::APIError] If OpenAI API request fails
       # @raise [AIClient::TimeoutError] If OpenAI API request times out
       # @raise [AIClient::ConfigurationError] If OpenAI API key is missing
-      def generate(prompt:, data_source: nil)
+      def generate(prompt:, data_source: nil, current_sql: nil)
         # Extract schema
         schema_extractor = SchemaExtractor.new
         schema = schema_extractor.extract(data_source)
 
-        # Generate SQL via AI
+        # Generate SQL via AI (with current_sql context if provided)
         ai_client = AIClient.new
-        response = ai_client.generate_query(prompt: prompt, schema: schema)
+        response = ai_client.generate_query(prompt: prompt, schema: schema, current_sql: current_sql)
 
         # Sanitize SQL if configured
         sanitized_sql = sanitize(response[:sql])

--- a/lib/blazer/querygen/schema_extractor.rb
+++ b/lib/blazer/querygen/schema_extractor.rb
@@ -3,8 +3,8 @@
 module Blazer
   module Querygen
     # Extracts database schema information without accessing actual data
-    class SchemaExtractor
-      def extract(data_source_name = nil)
+    class SchemaExtractor # rubocop:disable Metrics/ClassLength
+      def extract(data_source_name = nil) # rubocop:disable Metrics/MethodLength
         connection = get_connection(data_source_name)
         tables = get_tables(connection)
 
@@ -52,7 +52,7 @@ module Blazer
         end
       end
 
-      def get_table_comment(connection, table_name)
+      def get_table_comment(connection, table_name) # rubocop:disable Metrics/MethodLength
         return nil unless Blazer::Querygen.config.include_table_comments
 
         adapter = connection.adapter_name.downcase
@@ -67,7 +67,7 @@ module Blazer
         nil
       end
 
-      def get_column_comment(connection, table_name, column_name)
+      def get_column_comment(connection, table_name, column_name) # rubocop:disable Metrics/MethodLength
         return nil unless Blazer::Querygen.config.include_column_comments
 
         adapter = connection.adapter_name.downcase

--- a/test/blazer/querygen/ai_client_test.rb
+++ b/test/blazer/querygen/ai_client_test.rb
@@ -43,9 +43,9 @@ module Blazer
           schema: schema
         )
 
-        assert result[:sql].present?
+        assert_predicate result[:sql], :present?
         assert_includes result[:sql].downcase, "select"
-        assert result[:model].present?
+        assert_predicate result[:model], :present?
       end
 
       test "handles timeout gracefully" do
@@ -65,6 +65,7 @@ module Blazer
         }
 
         sql = @client.send(:extract_sql_from_response, response_with_markdown)
+
         assert_equal "SELECT * FROM users", sql
       end
 
@@ -78,6 +79,7 @@ module Blazer
         }
 
         sql = @client.send(:extract_sql_from_response, response_plain)
+
         assert_equal "SELECT * FROM products", sql
       end
 
@@ -95,6 +97,7 @@ module Blazer
         }
 
         sql = client.send(:extract_sql_from_response, response)
+
         assert_equal "SELECT id, name FROM users WHERE active = true", sql.strip
       end
 
@@ -169,11 +172,13 @@ module Blazer
 
           # Verify custom prompts work through PromptBuilder
           system_result = PromptBuilder.system_prompt
+
           assert_equal custom_system, system_result
 
           schema = [{ name: "users", columns: [{ name: "id", type: "integer", null: false, comment: nil }],
                       comment: nil }]
           user_result = PromptBuilder.build_user_prompt("Test", schema)
+
           assert_includes user_result, "Custom: Test"
         ensure
           Blazer::Querygen.config.system_prompt = original_prompt

--- a/test/blazer/querygen/ai_client_test.rb
+++ b/test/blazer/querygen/ai_client_test.rb
@@ -139,7 +139,8 @@ module Blazer
           Blazer::Querygen.config.api_key = "test-key"
           Blazer::Querygen.config.user_prompt_template = nil
 
-          schema = [{ name: "users", columns: [{ name: "id", type: "integer", null: false, comment: nil }], comment: nil }]
+          schema = [{ name: "users", columns: [{ name: "id", type: "integer", null: false, comment: nil }],
+                      comment: nil }]
 
           # Verify that PromptBuilder.build_user_prompt is called by checking its behavior
           prompt = PromptBuilder.build_user_prompt("Show all users", schema)
@@ -170,7 +171,8 @@ module Blazer
           system_result = PromptBuilder.system_prompt
           assert_equal custom_system, system_result
 
-          schema = [{ name: "users", columns: [{ name: "id", type: "integer", null: false, comment: nil }], comment: nil }]
+          schema = [{ name: "users", columns: [{ name: "id", type: "integer", null: false, comment: nil }],
+                      comment: nil }]
           user_result = PromptBuilder.build_user_prompt("Test", schema)
           assert_includes user_result, "Custom: Test"
         ensure

--- a/test/blazer/querygen/blazer_integration_test.rb
+++ b/test/blazer/querygen/blazer_integration_test.rb
@@ -9,11 +9,12 @@ module Blazer
         extractor = SchemaExtractor.new
         schema = extractor.extract
 
-        assert schema.is_a?(Array)
-        assert schema.any?
+        assert_kind_of Array, schema
+        assert_predicate schema, :any?
 
         # Check that we got the test tables
         table_names = schema.map { |t| t[:name] }
+
         assert_includes table_names, "users"
         assert_includes table_names, "products"
       end
@@ -23,9 +24,11 @@ module Blazer
         schema = extractor.extract
 
         users_table = schema.find { |t| t[:name] == "users" }
+
         assert users_table
 
         column_names = users_table[:columns].map { |c| c[:name] }
+
         assert_includes column_names, "id"
         assert_includes column_names, "email"
         assert_includes column_names, "name"

--- a/test/blazer/querygen/prompt_builder_test.rb
+++ b/test/blazer/querygen/prompt_builder_test.rb
@@ -92,6 +92,7 @@ module Blazer
 
       test "format_schema handles empty schema" do
         result = PromptBuilder.format_schema([])
+
         assert_equal "No schema information available.", result
       end
 

--- a/test/blazer/querygen/prompt_builder_test.rb
+++ b/test/blazer/querygen/prompt_builder_test.rb
@@ -68,14 +68,17 @@ module Blazer
 
       test "build_user_prompt uses custom template when configured" do
         original_template = Blazer::Querygen.config.user_prompt_template
-        custom_template = lambda do |user_input, formatted_schema|
-          "Custom: #{user_input} | Schema: #{formatted_schema}"
+        custom_template = lambda do |user_input, formatted_schema, current_sql|
+          result = "Custom: #{user_input} | Schema: #{formatted_schema}"
+          result += " | Current SQL: #{current_sql}" if current_sql
+          result
         end
 
         begin
           Blazer::Querygen.config.user_prompt_template = custom_template
 
-          schema = [{ name: "users", columns: [{ name: "id", type: "integer", null: false, comment: nil }], comment: nil }]
+          schema = [{ name: "users", columns: [{ name: "id", type: "integer", null: false, comment: nil }],
+                      comment: nil }]
 
           prompt = PromptBuilder.build_user_prompt("Show all users", schema)
 

--- a/test/blazer/querygen/query_generator_test.rb
+++ b/test/blazer/querygen/query_generator_test.rb
@@ -67,6 +67,7 @@ module Blazer
         safe_sql = "SELECT * FROM users"
         assert_nothing_raised do
           result = @generator.send(:sanitize, safe_sql)
+
           assert_equal safe_sql, result
         end
       end
@@ -75,6 +76,7 @@ module Blazer
         safe_sql = "SELECT id, email FROM users WHERE created_at > '2024-01-01'"
         assert_nothing_raised do
           result = @generator.send(:sanitize, safe_sql)
+
           assert_equal safe_sql, result
         end
       end
@@ -83,6 +85,7 @@ module Blazer
         safe_sql = "SELECT u.id, p.name FROM users u JOIN products p ON u.id = p.user_id"
         assert_nothing_raised do
           result = @generator.send(:sanitize, safe_sql)
+
           assert_equal safe_sql, result
         end
       end
@@ -98,6 +101,7 @@ module Blazer
           dangerous_sql = "DROP TABLE users"
           assert_nothing_raised do
             result = @generator.send(:sanitize, dangerous_sql)
+
             assert_equal dangerous_sql, result
           end
         ensure

--- a/test/blazer/querygen/schema_extractor_test.rb
+++ b/test/blazer/querygen/schema_extractor_test.rb
@@ -12,18 +12,20 @@ module Blazer
       test "extracts schema from default connection" do
         schema = @extractor.extract
 
-        assert schema.is_a?(Array)
-        assert schema.any?, "Schema should contain at least one table"
+        assert_kind_of Array, schema
+        assert_predicate schema, :any?, "Schema should contain at least one table"
 
         # Check first table structure
         table = schema.first
+
         assert table.key?(:name)
         assert table.key?(:columns)
-        assert table[:columns].is_a?(Array)
+        assert_kind_of Array, table[:columns]
 
         # Check column structure
         if table[:columns].any?
           column = table[:columns].first
+
           assert column.key?(:name)
           assert column.key?(:type)
         end
@@ -36,7 +38,7 @@ module Blazer
           Blazer::Querygen.config.max_tables_in_context = 2
           schema = @extractor.extract
 
-          assert schema.length <= 2, "Should respect max_tables_in_context limit"
+          assert_operator schema.length, :<=, 2, "Should respect max_tables_in_context limit"
         ensure
           Blazer::Querygen.config.max_tables_in_context = original_max
         end
@@ -50,6 +52,7 @@ module Blazer
           schema = @extractor.extract
 
           table_names = schema.map { |t| t[:name] }
+
           assert_not_includes table_names, "schema_migrations"
         ensure
           Blazer::Querygen.config.excluded_tables = original_excluded
@@ -60,7 +63,8 @@ module Blazer
         # This test assumes a connection with no tables
         # In reality, there will always be some tables
         schema = @extractor.extract
-        assert schema.is_a?(Array)
+
+        assert_kind_of Array, schema
       end
     end
   end

--- a/test/blazer/test_querygen.rb
+++ b/test/blazer/test_querygen.rb
@@ -2,13 +2,15 @@
 
 require "test_helper"
 
-class Blazer::TestQuerygen < Minitest::Test
-  def test_that_it_has_a_version_number
-    refute_nil ::Blazer::Querygen::VERSION
-  end
+module Blazer
+  class TestQuerygen < Minitest::Test
+    def test_that_it_has_a_version_number
+      refute_nil ::Blazer::Querygen::VERSION
+    end
 
-  def test_configuration_is_accessible
-    assert_respond_to ::Blazer::Querygen, :configure
-    assert_respond_to ::Blazer::Querygen, :config
+    def test_configuration_is_accessible
+      assert_respond_to ::Blazer::Querygen, :configure
+      assert_respond_to ::Blazer::Querygen, :config
+    end
   end
 end

--- a/test/controllers/blazer/prompts_controller_test.rb
+++ b/test/controllers/blazer/prompts_controller_test.rb
@@ -17,20 +17,24 @@ module Blazer
 
     test "health endpoint returns configured status" do
       get blazer_querygen_health_url
+
       assert_response :success
 
       json = JSON.parse(response.body)
+
       assert json.key?("status")
       assert json.key?("success")
     end
 
     test "run requires prompt parameter" do
       post blazer_run_prompt_url, params: { prompt: "" }, as: :json
+
       assert_response :unprocessable_entity
 
       json = JSON.parse(response.body)
-      assert_equal false, json["success"]
-      assert json["error"].present?
+
+      refute json["success"]
+      assert_predicate json["error"], :present?
     end
 
     test "run generates query with valid prompt" do
@@ -43,8 +47,9 @@ module Blazer
 
       assert_response :success
       json = JSON.parse(response.body)
+
       assert json["success"]
-      assert json["sql"].present?
+      assert_predicate json["sql"], :present?
     end
 
     test "run handles UnsafeQueryError with 422 status" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,7 @@ end
 
 # Configure Blazer::Querygen
 Blazer::Querygen.configure do |config|
-  config.api_key = ENV["OPENAI_API_KEY"]
+  config.api_key = ENV.fetch("OPENAI_API_KEY", nil)
   config.ai_model = "gpt-4o-mini" # Use cheaper model for tests
   config.timeout = 30
   config.max_tables_in_context = 10


### PR DESCRIPTION
Enable users to improve existing SQL queries by providing the current query as context to the AI. This allows for iterative refinement without needing to save each iteration.

Changes:
- Add current_sql optional parameter to query generation pipeline
- Update PromptBuilder to include current SQL in user prompt
- Update system prompt to guide AI on query improvement
- Extend JavaScript to capture and send current editor SQL
- Update custom template signature to accept current_sql
- Add backward-compatible tests for new parameter
- Auto-fix rubocop style issues

The feature works seamlessly with both new query generation and improvement of existing queries, maintaining full backward compatibility.

Resolves #1