### PR TITLE
feat: Add sandbox Rails app for manual testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,10 @@ secrets/
 credentials/
 *.key
 *.pem
+
+# Sandbox app artifacts
+test/sandbox/db/*.sqlite3
+test/sandbox/db/*.sqlite3-*
+test/sandbox/log/
+test/sandbox/tmp/
+test/sandbox/storage/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
   TargetRubyVersion: 3.2
   NewCops: enable
   SuggestExtensions: false
+  Exclude:
+    - "test/sandbox/**/*"
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
   SuggestExtensions: false
   Exclude:
     - "test/sandbox/**/*"
+    - "vendor/**/*"
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,7 @@ gem "rubocop", "~> 1.21"
 
 gem "rubocop-minitest", "~> 0.39.1", group: :development
 gem "rubocop-rake", "~> 0.7.1", group: :development
+
+# For sandbox app
+gem "propshaft"
+gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,9 +162,15 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.7.0)
+    propshaft (1.3.1)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
     psych (5.3.1)
       date
       stringio
+    puma (7.2.0)
+      nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.5)
     rack-session (2.1.1)
@@ -268,6 +274,8 @@ DEPENDENCIES
   blazer-querygen!
   irb
   minitest (~> 5.16)
+  propshaft
+  puma
   rake (~> 13.0)
   rubocop (~> 1.21)
   rubocop-minitest (~> 0.39.1)

--- a/README.md
+++ b/README.md
@@ -184,6 +184,23 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
+### Sandbox App
+
+A sandbox Rails application is included at `test/sandbox/` for manual testing. It comes pre-configured with Blazer, sample data (users, products, orders), and sample queries.
+
+```bash
+# Start the sandbox app (handles DB setup automatically on first run)
+bin/sandbox
+
+# With OpenAI API key for AI query generation
+OPENAI_API_KEY=your_key bin/sandbox
+
+# Reset the database
+rake sandbox:reset
+```
+
+Once running, open http://localhost:3000/blazer to access the Blazer UI with the querygen plugin.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/SonicGarden/blazer-querygen. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/SonicGarden/blazer-querygen/blob/master/CODE_OF_CONDUCT.md).

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,17 @@ require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
 task default: %i[test rubocop]
+
+namespace :sandbox do
+  desc "Start the sandbox Rails app for manual testing"
+  task :server do
+    exec "bin/sandbox"
+  end
+
+  desc "Reset the sandbox app database"
+  task :reset do
+    Dir.chdir("test/sandbox") do
+      system("bundle exec rails db:drop db:create db:migrate db:seed")
+    end
+  end
+end

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+SANDBOX_DIR="$(cd "$(dirname "$0")/../test/sandbox" && pwd)"
+cd "$SANDBOX_DIR"
+
+echo "=== Blazer::Querygen sandbox app ==="
+echo ""
+
+# Setup database
+if [ ! -f db/development.sqlite3 ]; then
+  echo "Setting up database..."
+  bundle exec rails db:create db:migrate db:seed
+  echo ""
+else
+  echo "Running pending migrations..."
+  bundle exec rails db:migrate 2>/dev/null || true
+  echo ""
+fi
+
+if [ -n "$OPENAI_API_KEY" ]; then
+  echo "OpenAI API key detected - AI query generation enabled"
+else
+  echo "WARNING: OPENAI_API_KEY not set"
+  echo "  Set it with: OPENAI_API_KEY=your_key bin/sandbox"
+fi
+
+echo ""
+echo "Starting server at http://localhost:3000/blazer"
+echo ""
+
+exec bundle exec rails server -p 3000

--- a/test/sandbox/Rakefile
+++ b/test/sandbox/Rakefile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "config/application"
+Rails.application.load_tasks

--- a/test/sandbox/app/controllers/application_controller.rb
+++ b/test/sandbox/app/controllers/application_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationController < ActionController::Base
+end

--- a/test/sandbox/app/models/application_record.rb
+++ b/test/sandbox/app/models/application_record.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/test/sandbox/app/models/order.rb
+++ b/test/sandbox/app/models/order.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Order < ApplicationRecord
+  enum :status, { pending: 0, processing: 1, shipped: 2, delivered: 3, cancelled: 4 }
+  enum :priority, { low: 0, medium: 1, high: 2 }
+
+  belongs_to :user
+  has_many :order_items, dependent: :destroy
+end

--- a/test/sandbox/app/models/order_item.rb
+++ b/test/sandbox/app/models/order_item.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class OrderItem < ApplicationRecord
+  belongs_to :order
+  belongs_to :product
+end

--- a/test/sandbox/app/models/product.rb
+++ b/test/sandbox/app/models/product.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Product < ApplicationRecord
+  has_many :order_items, dependent: :destroy
+end

--- a/test/sandbox/app/models/user.rb
+++ b/test/sandbox/app/models/user.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  has_many :orders, dependent: :destroy
+end

--- a/test/sandbox/app/views/layouts/blazer/application.html.erb
+++ b/test/sandbox/app/views/layouts/blazer/application.html.erb
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= blazer_title ? blazer_title : "Blazer" %></title>
+
+    <meta charset="utf-8" />
+    <%= favicon_link_tag "blazer/favicon.png" %>
+    <% if defined?(Propshaft::Railtie) && Rails.application.assets.is_a?(Propshaft::Assembly) %>
+      <%= stylesheet_link_tag "blazer/bootstrap-propshaft", "blazer/bootstrap", "blazer/selectize", "blazer/github", "blazer/daterangepicker", "blazer/application" %>
+      <%= javascript_include_tag "blazer/jquery", "blazer/rails-ujs", "blazer/stupidtable", "blazer/stupidtable-custom-settings", "blazer/jquery.stickytableheaders", "blazer/selectize", "blazer/highlight.min", "blazer/moment", "blazer/moment-timezone-with-data", "blazer/daterangepicker", "blazer/chart.umd", "blazer/chartjs-adapter-date-fns.bundle", "blazer/chartkick", "blazer/mapkick.bundle", "blazer/ace/ace", "blazer/ace/ext-language_tools", "blazer/ace/theme-twilight", "blazer/ace/mode-sql", "blazer/ace/snippets/text", "blazer/ace/snippets/sql", "blazer/Sortable", "blazer/bootstrap", "blazer/vue.global.prod", "blazer/routes", "blazer/queries", "blazer/fuzzysearch", "blazer/application", nonce: true %>
+    <% else %>
+      <%= stylesheet_link_tag "blazer/application" %>
+      <%= javascript_include_tag "blazer/application", nonce: true %>
+    <% end %>
+    <%= javascript_tag nonce: true do %>
+      <%= blazer_js_var "rootPath", root_path %>
+    <% end %>
+
+    <%= blazer_querygen_javascript %>
+
+    <%= csrf_meta_tags %>
+  </head>
+  <body>
+    <div class="container">
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/test/sandbox/bin/rails
+++ b/test/sandbox/bin/rails
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/test/sandbox/bin/rake
+++ b/test/sandbox/bin/rake
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../config/boot"
+require "rake"
+Rake.application.run

--- a/test/sandbox/config.ru
+++ b/test/sandbox/config.ru
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "config/environment"
+run Rails.application

--- a/test/sandbox/config/application.rb
+++ b/test/sandbox/config/application.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "boot"
+
+require "rails"
+require "active_model/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_view/railtie"
+
+require "propshaft"
+require "blazer"
+require "blazer/querygen"
+
+Bundler.require(*Rails.groups)
+
+module Dummy
+  class Application < Rails::Application
+    config.load_defaults 7.1
+    config.eager_load = false
+    config.secret_key_base = "dummy-app-secret-key-base-for-development-only"
+  end
+end

--- a/test/sandbox/config/blazer.yml
+++ b/test/sandbox/config/blazer.yml
@@ -1,0 +1,7 @@
+data_sources:
+  main:
+    smart_variables: {}
+    linked_columns: {}
+    smart_columns: {}
+
+audit: true

--- a/test/sandbox/config/boot.rb
+++ b/test/sandbox/config/boot.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
+require "bundler/setup"

--- a/test/sandbox/config/database.yml
+++ b/test/sandbox/config/database.yml
@@ -1,0 +1,12 @@
+default: &default
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+
+development:
+  <<: *default
+  database: db/development.sqlite3
+
+test:
+  <<: *default
+  database: db/test.sqlite3

--- a/test/sandbox/config/environment.rb
+++ b/test/sandbox/config/environment.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "application"
+Rails.application.initialize!

--- a/test/sandbox/config/environments/development.rb
+++ b/test/sandbox/config/environments/development.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.cache_classes = false
+  config.eager_load = false
+  config.consider_all_requests_local = true
+  config.server_timing = true
+  config.action_controller.perform_caching = false
+end

--- a/test/sandbox/config/initializers/blazer_querygen.rb
+++ b/test/sandbox/config/initializers/blazer_querygen.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Blazer::Querygen.configure do |config|
+  config.ai_model = "gpt-4o-mini"
+  config.api_key = ENV.fetch("OPENAI_API_KEY", nil)
+  config.timeout = 30
+  config.max_retries = 3
+  config.max_tables_in_context = 50
+  config.sanitize_queries = true
+  config.allowed_operations = [:select]
+  config.excluded_tables = %w[schema_migrations ar_internal_metadata blazer_queries blazer_audits blazer_dashboards blazer_dashboard_queries blazer_checks]
+  config.include_table_comments = true
+  config.include_column_comments = true
+  config.include_enum_values = true
+end

--- a/test/sandbox/config/routes.rb
+++ b/test/sandbox/config/routes.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  mount Blazer::Engine, at: "/blazer"
+  root to: redirect("/blazer")
+end

--- a/test/sandbox/db/migrate/001_install_blazer.rb
+++ b/test/sandbox/db/migrate/001_install_blazer.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class InstallBlazer < ActiveRecord::Migration[7.1]
+  def change
+    create_table :blazer_queries do |t|
+      t.references :creator
+      t.string :name
+      t.text :description
+      t.text :statement
+      t.string :data_source
+      t.string :status
+      t.timestamps null: false
+    end
+
+    create_table :blazer_audits do |t|
+      t.references :user
+      t.references :query
+      t.text :statement
+      t.string :data_source
+      t.datetime :created_at
+    end
+
+    create_table :blazer_dashboards do |t|
+      t.references :creator
+      t.string :name
+      t.timestamps null: false
+    end
+
+    create_table :blazer_dashboard_queries do |t|
+      t.references :dashboard
+      t.references :query
+      t.integer :position
+      t.timestamps null: false
+    end
+
+    create_table :blazer_checks do |t|
+      t.references :creator
+      t.references :query
+      t.string :state
+      t.string :schedule
+      t.text :emails
+      t.text :slack_channels
+      t.string :check_type
+      t.text :message
+      t.datetime :last_run_at
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/sandbox/db/migrate/002_create_sample_tables.rb
+++ b/test/sandbox/db/migrate/002_create_sample_tables.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CreateSampleTables < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.string :name, null: false
+      t.string :role, default: "member"
+      t.timestamps
+    end
+
+    create_table :products do |t|
+      t.string :name, null: false
+      t.text :description
+      t.decimal :price, precision: 10, scale: 2
+      t.string :category
+      t.integer :stock_count, default: 0
+      t.timestamps
+    end
+
+    create_table :orders do |t|
+      t.references :user, foreign_key: true
+      t.integer :status, default: 0
+      t.integer :priority, default: 0
+      t.decimal :total_amount, precision: 10, scale: 2
+      t.timestamps
+    end
+
+    create_table :order_items do |t|
+      t.references :order, foreign_key: true
+      t.references :product, foreign_key: true
+      t.integer :quantity, default: 1
+      t.decimal :unit_price, precision: 10, scale: 2
+      t.timestamps
+    end
+  end
+end

--- a/test/sandbox/db/schema.rb
+++ b/test/sandbox/db/schema.rb
@@ -1,0 +1,112 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2) do
+  create_table "blazer_audits", force: :cascade do |t|
+    t.datetime "created_at"
+    t.string "data_source"
+    t.integer "query_id"
+    t.text "statement"
+    t.integer "user_id"
+    t.index ["query_id"], name: "index_blazer_audits_on_query_id"
+    t.index ["user_id"], name: "index_blazer_audits_on_user_id"
+  end
+
+  create_table "blazer_checks", force: :cascade do |t|
+    t.string "check_type"
+    t.datetime "created_at", null: false
+    t.integer "creator_id"
+    t.text "emails"
+    t.datetime "last_run_at"
+    t.text "message"
+    t.integer "query_id"
+    t.string "schedule"
+    t.text "slack_channels"
+    t.string "state"
+    t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_blazer_checks_on_creator_id"
+    t.index ["query_id"], name: "index_blazer_checks_on_query_id"
+  end
+
+  create_table "blazer_dashboard_queries", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "dashboard_id"
+    t.integer "position"
+    t.integer "query_id"
+    t.datetime "updated_at", null: false
+    t.index ["dashboard_id"], name: "index_blazer_dashboard_queries_on_dashboard_id"
+    t.index ["query_id"], name: "index_blazer_dashboard_queries_on_query_id"
+  end
+
+  create_table "blazer_dashboards", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "creator_id"
+    t.string "name"
+    t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_blazer_dashboards_on_creator_id"
+  end
+
+  create_table "blazer_queries", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "creator_id"
+    t.string "data_source"
+    t.text "description"
+    t.string "name"
+    t.text "statement"
+    t.string "status"
+    t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_blazer_queries_on_creator_id"
+  end
+
+  create_table "order_items", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "order_id"
+    t.integer "product_id"
+    t.integer "quantity", default: 1
+    t.decimal "unit_price", precision: 10, scale: 2
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_order_items_on_order_id"
+    t.index ["product_id"], name: "index_order_items_on_product_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "priority", default: 0
+    t.integer "status", default: 0
+    t.decimal "total_amount", precision: 10, scale: 2
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
+  create_table "products", force: :cascade do |t|
+    t.string "category"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.decimal "price", precision: 10, scale: 2
+    t.integer "stock_count", default: 0
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.string "name", null: false
+    t.string "role", default: "member"
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "order_items", "orders"
+  add_foreign_key "order_items", "products"
+  add_foreign_key "orders", "users"
+end

--- a/test/sandbox/db/seeds.rb
+++ b/test/sandbox/db/seeds.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+puts "Seeding database..."
+
+# Users
+users = 10.times.map do |i|
+  User.create!(
+    name: "User #{i + 1}",
+    email: "user#{i + 1}@example.com",
+    role: %w[admin member member member moderator][i % 5]
+  )
+end
+puts "  Created #{users.size} users"
+
+# Products
+categories = %w[Electronics Books Clothing Food]
+products = 20.times.map do |i|
+  Product.create!(
+    name: "Product #{i + 1}",
+    description: "Description for product #{i + 1}",
+    price: (rand(5.0..200.0)).round(2),
+    category: categories[i % categories.length],
+    stock_count: rand(0..100)
+  )
+end
+puts "  Created #{products.size} products"
+
+# Orders with items
+orders_count = 0
+30.times do
+  order = Order.create!(
+    user: users.sample,
+    status: rand(0..4),
+    priority: rand(0..2),
+    total_amount: 0
+  )
+
+  total = 0
+  rand(1..4).times do
+    product = products.sample
+    quantity = rand(1..3)
+    total += product.price * quantity
+    OrderItem.create!(
+      order: order,
+      product: product,
+      quantity: quantity,
+      unit_price: product.price
+    )
+  end
+  order.update!(total_amount: total.round(2))
+  orders_count += 1
+end
+puts "  Created #{orders_count} orders with items"
+
+# Sample Blazer queries
+Blazer::Query.create!(
+  name: "All Users",
+  statement: "SELECT * FROM users ORDER BY created_at DESC",
+  data_source: "main"
+)
+Blazer::Query.create!(
+  name: "Orders by Status",
+  statement: "SELECT status, COUNT(*) as count FROM orders GROUP BY status",
+  data_source: "main"
+)
+Blazer::Query.create!(
+  name: "Top Products by Revenue",
+  statement: <<~SQL,
+    SELECT p.name, SUM(oi.quantity * oi.unit_price) as revenue
+    FROM order_items oi
+    JOIN products p ON p.id = oi.product_id
+    GROUP BY p.name
+    ORDER BY revenue DESC
+  SQL
+  data_source: "main"
+)
+puts "  Created 3 sample Blazer queries"
+
+puts "Done!"


### PR DESCRIPTION
## Summary

- Add a minimal Rails sandbox app (`test/sandbox/`) pre-configured with Blazer and blazer-querygen for easy manual testing
- Include `bin/sandbox` script that handles DB setup and server startup in one command
- Add sample data (users, products, orders) and sample Blazer queries for meaningful testing

## Test plan

- [x] Run `bin/sandbox` and verify the app starts at http://localhost:3000/blazer
- [x] Verify Blazer UI loads with sample queries
- [x] Verify AI prompt UI appears on query editor page
- [x] Run `OPENAI_API_KEY=key bin/sandbox` and test SQL generation
- [x] Verify `bundle exec rake test` still passes
- [x] Verify `bundle exec rake rubocop` still passes