### PR TITLE
fix: Use to_h for Style/ReduceToHash cop

### DIFF
--- a/lib/blazer/querygen/enum_extractor.rb
+++ b/lib/blazer/querygen/enum_extractor.rb
@@ -88,7 +88,7 @@ module Blazer
 
         model.enumerized_attributes.each_with_object({}) do |attr, result|
           values = attr.values.map(&:to_s)
-          result[attr.name.to_s] = values.each_with_object({}) { |v, h| h[v] = v }
+          result[attr.name.to_s] = values.to_h { |v| [v, v] }
         end
       rescue StandardError
         {}


### PR DESCRIPTION
## Summary
- RuboCop 1.85 の新ルール `Style/ReduceToHash` に対応
- `each_with_object({})` を `to_h` に置き換え
- Dependabot PR #11 (rubocop 1.85.1) のマージを unblock するための修正

## Test plan
- [x] CI (rubocop + テスト) がパスすることを確認
- [ ] マージ後に #11 をリベース・マージ