### PR TITLE
fix: update action_text-trix to 2.1.18 for XSS vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.17)
+    action_text-trix (2.1.18)
       railties
     actioncable (8.1.3)
       actionpack (= 8.1.3)
@@ -85,7 +85,7 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.0)
     blazer (3.3.0)
       activerecord (>= 7.1)
       chartkick (>= 5)
@@ -136,7 +136,7 @@ GEM
       net-smtp
     marcel (1.1.0)
     mini_mime (1.1.5)
-    minitest (6.0.2)
+    minitest (6.0.3)
       drb (~> 2.0)
       prism (~> 1.5)
     multipart-post (2.4.1)
@@ -174,7 +174,7 @@ GEM
     puma (7.2.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.5)
+    rack (3.2.6)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)


### PR DESCRIPTION
## Summary
- `action_text-trix` を 2.1.17 → 2.1.18 に更新
- Trix の drag-and-drop（Level0InputController）における JSON デシリアライゼーションバイパスを利用した XSS 脆弱性を修正

## Security Advisory
- **GHSA**: [GHSA-53p3-c7vp-4mcc](https://github.com/basecamp/trix/security/advisories/GHSA-53p3-c7vp-4mcc)
- **対応**: `>= 2.1.18` へのアップデート

## Test plan
- [x] `bundle exec rake test` 全テスト通過（66 runs, 138 assertions, 0 failures）